### PR TITLE
Eliminate PyAudio from the Conda environment due to issues, opting in…

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         # Conda doesn't currently offer a built-in way to specifically skip a
         # single package during environment creation, like:
-        # conda env create --file commbase_env.yaml --name commbase_env --skip pyaudio
+        conda env create --file commbase_env.yaml --name commbase_env
         #conda env update --file commbase_env.yaml --name commbase_env
 
     - name: Lint with flake8

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -36,4 +36,5 @@ jobs:
       run: |
         conda install pytest
         sudo apt install espeak
+        pip install pyttsx3
         pytest

--- a/commbase_env.yaml
+++ b/commbase_env.yaml
@@ -140,7 +140,6 @@ dependencies:
       - opencv-python==4.9.0.80
       - packaging==23.2
       - pillow==10.2.0
-      - pyaudio==0.2.14
       - pydub==0.25.1
       - pytesseract==0.3.10
       - pyttsx3==2.90


### PR DESCRIPTION
…stead for the GitHub action to rebuild the environment on Ubuntu, even though the process encounters failure.